### PR TITLE
feat: use python3 and env file

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,5 @@
+GITHUB_USER=umputun
+GITHUB_ACCESS_TOKEN=token
+TIME_ZONE=America/Chicago
+SLEEP="1d"
+ARGS="--all --private"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.9
+FROM alpine:3.15
 
-RUN apk add --update --no-cache tzdata git python py-pip tzdata
-RUN pip install github-backup && github-backup -v
+RUN apk add --update --no-cache tzdata git python3 py-pip tzdata
+RUN pip3 install github-backup && github-backup -v
 COPY exec.sh /srv/exec.sh
 RUN chmod +x /srv/exec.sh
 CMD ["/srv/exec.sh"]

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ Dockerized version of [python-github-backup](https://github.com/josegonzalez/pyt
 ## Install and run
 
 1. Generate github [access token](https://github.com/settings/tokens)
-2. Get provided `docker-compose.yml`. If needed change the mapping for `volumes` and `MAX_BACKUPS` number
-3. Change TZ (see the [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
-4. Set both `GITHUB_USER` and `GITHUB_ACCESS_TOKEN` (in environment or directly in `docker-compose.yml`)
-5. Run `docker-compose up -d` to initiate daily backup 
+2. Get provided `docker-compose.yml`. If needed change the mapping for `volumes`
+3. Copy `.env-example` file to `.env` and fill variables. Change TZ (see the [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
+4. Run `docker-compose up -d` to initiate daily backup
 
 ## Build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 services:
   github-backup:
@@ -17,7 +17,8 @@ services:
     environment:
       - GITHUB_USER
       - TOKEN=${GITHUB_ACCESS_TOKEN}
-      - MAX_BACKUPS=10
-      - TIME_ZONE=America/Chicago
+      - TIME_ZONE
+      - SLEEP
+      - ARGS
     volumes:
       - ./var:/srv/var

--- a/exec.sh
+++ b/exec.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-TIME_ZONE=${TIME_ZONE:=UTC}
+TIME_ZONE=${TIME_ZONE:="UTC"}
+ARGS=${ARGS:="--repositories --private --gists"}
+SLEEP=${SLEEP:="1d"}
+echo "args=${ARGS}"
 echo "timezone=${TIME_ZONE}"
+echo "sleep=${SLEEP}"
 cp /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime
 echo "${TIME_ZONE}" >/etc/timezone
 
@@ -11,13 +15,9 @@ while :; do
 
     for u in $(echo $GITHUB_USER | tr "," "\n"); do
         echo "$(date) - execute backup for ${u}, ${DATE}"
-        github-backup ${u} --token=$TOKEN --all --output-directory=/srv/var/${DATE}/${u} --private --gists
+        github-backup ${u} --token=$TOKEN --output-directory=/srv/var/${u} ${ARGS}
     done
 
-    echo "$(date) - cleanup"
-
-    ls -d1 /srv/var/* | head -n -${MAX_BACKUPS} | xargs rm -rf
-
-    echo "$(date) - sleep for 1 day"
-    sleep 1d
+    echo "$(date) - sleep for ${SLEEP}"
+    sleep "${SLEEP}"
 done


### PR DESCRIPTION
* python2 is not working anymore, we should use python3
* move configuration parameters to env file
* create `.env-example` file
* info to README file
* store backups in one directory
* specify SLEEP and ARGS from env
* update alpine version