### PR TITLE
feat: allow backup options to be customized through BACKUP_OPTIONS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Dockerized version of [python-github-backup](https://github.com/josegonzalez/pyt
 5. Set `GITHUB_USER` (Github user accounts) and/or `GITHUB_ORG` (Github Organizations; make sure the user token has access to the organization). If you have multiple users/organizations, you can list thme separating names by a comma.
 6. Run `docker-compose up -d` to initiate daily backup 
 
+## Customize Backup Options
+
+The underlying [python-github-backup](https://github.com/josegonzalez/python-github-backup) library [has a lot of options](https://github.com/josegonzalez/python-github-backup#usage) to customize what is backed up from github. 
+
+We can customize this by using the `BACKUP_OPTIONS` environment variable. By default, the container will backup everything and uses `--private --all --gist`. That will backup the repositories, issues, pull requests, labels, etc.
+
+If you wanted to customize this to only backup the repository code (including private repositories), you could define the following on your `docker-compose.yml` file's environment:
+
+```
+BACKUP_OPTIONS=--private --repositories
+```
+
 ## Prepared images
 
 - [docker hub](https://hub.docker.com/r/umputun/github-backup-docker/tags)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,6 @@ services:
       - TOKEN=${GITHUB_ACCESS_TOKEN}
       - MAX_BACKUPS=10
       - TIME_ZONE=America/Chicago
+      - BACKUP_OPTIONS=--all --private --gists
     volumes:
       - ./var:/srv/var

--- a/exec.sh
+++ b/exec.sh
@@ -2,6 +2,10 @@
 
 TIME_ZONE=${TIME_ZONE:=UTC}
 echo "timezone=${TIME_ZONE}"
+
+BACKUP_OPTIONS=${BACKUP_OPTIONS:='--all --private --gists'}
+echo "backup options=${BACKUP_OPTIONS}"
+
 cp /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime
 echo "${TIME_ZONE}" >/etc/timezone
 
@@ -15,7 +19,7 @@ while :; do
     else
       for u in $(echo $GITHUB_USER | tr "," "\n"); do
         echo "$(date) - execute backup for User ${u}, ${DATE}"
-        github-backup ${u} --token=$TOKEN --all --output-directory=/srv/var/${DATE}/${u} --private --gists
+        github-backup ${u} --token=$TOKEN --output-directory=/srv/var/${DATE}/${u} ${BACKUP_OPTIONS}
       done
   fi
 
@@ -25,7 +29,7 @@ while :; do
     else
       for o in $(echo $GITHUB_ORG | tr "," "\n"); do
         echo "$(date) - execute backup for Organization ${u}, ${DATE}"
-        github-backup ${o} --organization --token=$TOKEN --all --output-directory=/srv/var/${DATE}/${o} --private --gists
+        github-backup ${o} --organization --token=$TOKEN --output-directory=/srv/var/${DATE}/${o} ${BACKUP_OPTIONS}
       done
 	fi
 


### PR DESCRIPTION
The default of `--all --private --gists` is a little heavy on the github request throttling limits if you have a lot of repos with a lot of issues / prs /etc.

This PR adds a `BACKUP_OPTIONS` env variable which defaults to the current behavior but allows you to customize with something like `--private --repositories` if all you care about is getting the repository code backed up. This resulted in me seeing `1` api request per page of repos instead of thousands for each repos issues/prs/etc.